### PR TITLE
Wrote a setup.py that works on Linux.  It works if Python is compile with g++.

### DIFF
--- a/ptm.py
+++ b/ptm.py
@@ -36,8 +36,9 @@ def PTM(atoms, structures=None, alloys=False, cutoff=10.0):
         nearest = np.argsort(sqdist)[:14]
         positions = np.zeros((15,3))
         positions[1:] = relative_positions[nearest]
-        struct, alloy, rmsd, rot, nb_permut = ptmmodule.index_structure(positions)
-        result[i] = struct
+        data = ptmmodule.index_structure(positions)
+        #struct, alloy, rmsd, rot, nb_permut = xxx
+        result[i] = data[0]
     return result
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,27 @@
 #!/usr/bin/env python
 
-raise RuntimeError("THIS setup.py FILE HAS NOT BEEN FINISHED: Please type make to build instead.")
+# NOTE: This setup.py script requires that Python is compiled with a
+# C++ compiler, and that this compiler supports C++11.  This is only
+# occationally the case!
 
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext as _build_ext
 from glob import glob
+import os
 
 c_src_files = glob('*.c')
-cpp_src_files = glob('*.cpp')
+cpp_src_files = glob('*.cpp') + glob('svdpolar/*.cpp')
 extra_compile_args = ['-std=c++11']
 
-name = 'polyhedraltemplatematching'
+name = 'ptmmodule'
 
+class build_ext(_build_ext):
+    def finalize_options(self):
+        _build_ext.finalize_options(self)
+        # Prevent numpy from thinking it is still in its setup process:
+        __builtins__.__NUMPY_SETUP__ = False
+        import numpy
+        self.include_dirs.append(os.path.join(numpy.get_include(), 'numpy'))
 
 
 setup(name=name,
@@ -20,4 +31,6 @@ setup(name=name,
                              extra_compile_args=extra_compile_args,
                              )
                   ],
+      setup_requires=['numpy'],
+      cmdclass={'build_ext':build_ext},
       )


### PR DESCRIPTION
It can now be build with the standard Python extension building mechanism (python setup.py install); but it only works if the Python installation was compiled with C++ and if that C++ compiler supports C++11.  Unfortunately, python is often build with gcc rather than g++, and while gcc can compile C++ code, it does not always accept the flag enabling C++11 support.  I will work on this, and submit a separate pull request.
