### PR TITLE
Adapt for inclusion in Asap.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ all: $(OBJDIR) $(OBJDIR)/$(PYTHONMODULE)
 
 # Rule for linking module
 $(OBJDIR)/$(PYTHONMODULE): $(C_OBJECT_FILES) $(C_OBJECT_SVDPOLAR_FILES)
-	$(CC) $(MAKESHARED) -fPIC -g -O2 -o $@ $^ -z defs -L$(PYTHONLIBDIR) -l$(PYTHONLIB) -lm
+	$(CC) $(MAKESHARED) -fPIC -g -O2 -o $@ $^ -L$(PYTHONLIBDIR) -l$(PYTHONLIB) -lm
 
 $(OBJDIR):
 	mkdir $(OBJDIR)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ HEADER_FILES = alloy_types.h canonical.h convex_hull_incremental.h \
 	normalize_vertices.h qcprot.h quat.h reference_templates.h \
 	svdpolar/polar_decomposition.h
 
-OBJDIR = obj
+OBJDIR = .
 
 C_OBJECT_FILES = $(C_SRC_FILES:%.c=$(OBJDIR)/%.o) 
 C_OBJECT_SVDPOLAR_FILES = $(C_SRC_SVDPOLAR_FILES:%.c=$(OBJDIR)/%.o) 

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,19 @@ CC = gcc
 
 C_SRC_FILES = ptmmodule.c canonical.c graph_data.c convex_hull_incremental.c \
 	index_PTM.c alloy_types.c qcprot.c deformation_gradient.c \
-	normalize_vertices.c quat.c svdpolar/polar_decomposition.c
+	normalize_vertices.c quat.c
+
+C_SRC_SVDPOLAR_FILES = polar_decomposition.c
 
 HEADER_FILES = alloy_types.h canonical.h convex_hull_incremental.h \
 	deformation_gradient.h graph_data.h index_PTM.h \
 	normalize_vertices.h qcprot.h quat.h reference_templates.h \
 	svdpolar/polar_decomposition.h
 
-C_OBJECT_FILES = $(C_SRC_FILES:%.c=%.o)
+OBJDIR = obj
+
+C_OBJECT_FILES = $(C_SRC_FILES:%.c=$(OBJDIR)/%.o) 
+C_OBJECT_SVDPOLAR_FILES = $(C_SRC_SVDPOLAR_FILES:%.c=$(OBJDIR)/%.o) 
 
 PYTHONMODULE = ptmmodule.so
 
@@ -32,19 +37,27 @@ else
 MAKESHARED = -shared
 endif
 
+all: $(OBJDIR) $(OBJDIR)/$(PYTHONMODULE)
+
 # Rule for linking module
-$(PYTHONMODULE): $(C_OBJECT_FILES)
-	$(CC) $(MAKESHARED) -fPIC -g -O2 -o $(PYTHONMODULE) $(C_OBJECT_FILES) -z defs -L$(PYTHONLIBDIR) -l$(PYTHONLIB) -lm
+$(OBJDIR)/$(PYTHONMODULE): $(C_OBJECT_FILES) $(C_OBJECT_SVDPOLAR_FILES)
+	$(CC) $(MAKESHARED) -fPIC -g -O2 -o $@ $^ -z defs -L$(PYTHONLIBDIR) -l$(PYTHONLIB) -lm
+
+$(OBJDIR):
+	mkdir $(OBJDIR)
 
 # Lazy again: all object files depend on all header files
-%.o: $(HEADER_FILES)
+$(OBJDIR)/%.o: $(HEADER_FILES)
 
 # Rule for compiling C source
-%.o: %.c
+$(OBJDIR)/%.o: svdpolar/%.c
+	$(CC) -c $(CFLAGS) $(INCLUDES) -o $@ -I$(PYTHONINCLDIR) -I$(NUMPY_INCLUDE) $<
+
+$(OBJDIR)/%.o: %.c
 	$(CC) -c $(CFLAGS) $(INCLUDES) -o $@ -I$(PYTHONINCLDIR) -I$(NUMPY_INCLUDE) $<
 
 clean:
-	-rm *.o ptmmodule.so
+	rm -f $(OBJDIR)/*.o $(OBJDIR)/ptmmodule.so
 
 cleanall: clean
-	rm -r build
+	rm -rf build

--- a/ptm.py
+++ b/ptm.py
@@ -9,41 +9,110 @@ import ptmmodule
 import numpy as np
 
 
-def PTM(atoms, structures=None, alloys=False, cutoff=10.0):
+def PTM(atoms, target_structures=None, calculate_strains=False, cutoff=10.0):
     """Run Complex Hull Analysis on an Atoms object.
 
     Parameters:
     atoms: The atoms object
 
-    structures=None: The list of structures to be investigated.
-        The list defaults to ('sc', 'fcc', 'hcp', 'ico', 'bcc').
-
-    alloys=False: Set to true to check for alloy structures.
+    target_structures=None: A tuple of structures to be investigated.
+        It defaults to ('sc', 'fcc', 'hcp', 'ico', 'bcc').
+        It MUST be a tuple, not a list or other sequence (bug?).
     
+    calculate_strains=False: Set to True to calculate strains.
+
     cutoff: A cutoff used for the neighborlist.  Must be large enough that all
         nearest neighbors are returned (second-nearest for BCC).  Using a too
         large value may impact performance, but not results.
         
     Returns:
-    Well, we will see...
+    (structures, alloytypes, rmsds, scales, rotations, [strains])
+    Each of these are a NumPy array of the same length as the number of atoms.
+    For each atom, the data returned is
+
+    structures[i]: The local crystal structure around atom i, if any.
+         0 = none; 1 = SC; 2 = FCC; 3 = HCP; 4 = Icosahedral; 5 = BCC.
+
+    alloytypes[i]: The alloy structure identified.
+         0 = unidentified; 1 = pure element; 2 = L1_0;
+         3 = L1_2 majority atom; 4 = L1_2 minority atom.
+         (0 is returned if structures[i] != 2 or if no known alloy structure
+         is recognized)
+
+    rmsds[i]: The RMSD error in the fitting to the template, or INF if
+         no structure was identified.
+
+    scales[i]: The average distance to the nearest neighbors for
+         structures 1-4; or the average distance to nearest and
+         next-nearest neighbors for structure 5 (BCC); or INF if no
+         structure was identified.
+
+    rotations[i]: The rotation of the crystal lattice, expressed as a
+         unit quaternion.  If no structure was found, the illegal
+         value (0, 0, 0, 0) is returned.
+
+    strains[i] (only returned if calculate_strains=True).  The strain
+         tensor as a symmetric 3x3 matrix.  The trace of the matrix is
+         1.0, since a hydrostatic component of the strain cannot be
+         determined without a-priori knowledge of the reference
+         lattice parameter.  If such knowledge is available, the
+         hydrostatic component of the strain can be calculated from
+         scales[i].
+
     """
 
     nblist = asap3.FullNeighborList(cutoff, atoms)
-    result = np.zeros(len(atoms), int)
+    structures = np.zeros(len(atoms), int)
+    alloys = np.zeros(len(atoms), int)
+    rmsds = np.zeros(len(atoms))
+    scales = np.zeros(len(atoms))
+    rotations = np.zeros((len(atoms), 4))
+    if calculate_strains:
+        strains = np.zeros((len(atoms), 3, 3))
+    z_all = atoms.get_atomic_numbers()
     for i in range(len(atoms)):
         indices, relative_positions, sqdist = nblist.get_neighbors(i)
         assert(len(indices) >= 14)
         nearest = np.argsort(sqdist)[:14]
         positions = np.zeros((15,3))
         positions[1:] = relative_positions[nearest]
-        data = ptmmodule.index_structure(positions)
-        #struct, alloy, rmsd, rot, nb_permut = xxx
-        result[i] = data[0]
-    return result
+
+        z = np.zeros(15, np.int32)
+        z[0] = z_all[i]
+        z[1:] = z_all[indices[nearest]]
+        print z.dtype
+        data = ptmmodule.index_structure(positions, z, 
+                                         calculate_strains=calculate_strains)
+        # data = (struct, alloy, rmsd, scale, rotation)
+        structures[i], alloys[i], rmsds[i], scales[i] = data[:4]
+        if structures[i]:
+            rotations[i] = data[4]
+            if calculate_strains:
+                strains[i] = data[7]
+    if calculate_strains:
+        return structures, alloys, rmsds, scales, rotations, strains
+    else:
+        return structures, alloys, rmsds, scales, rotations
 
 if __name__ == "__main__":
     from ase.lattice.cubic import FaceCenteredCubic
     atoms = FaceCenteredCubic("Cu", size=(7,7,7), pbc=False)
-    ptm = PTM(atoms)
-    print ptm
-    print np.bincount(ptm)
+    structures, alloys, rmsds, scales, rotations, strains = PTM(atoms, calculate_strains=True)
+    print structures
+    print np.bincount(structures)
+    print 
+    print alloys
+    print rmsds
+    print scales
+    print rotations
+    print
+
+    # In the following, surface atoms will have type 0, or be detected
+    # as 1 or 2 with a high rmsd and a strange rotation whereas bulk
+    # atoms will be correctly identified as type 2 (fcc) with very
+    # small rmsd and rotation (1,0,0,0).
+
+    for s, a, r, sc, rot in zip(structures, alloys, rmsds, scales, 
+                                   rotations):
+        print s, a, r, sc, rot
+

--- a/ptm.py
+++ b/ptm.py
@@ -2,6 +2,10 @@
 
 This module runs Polyhedral Template Matching on an Atoms object from ASE/Asap.
 It requires that both ASE and Asap are installed.
+
+This module can also be used as inspiration for how to use Polyhedral Template
+Matching in other codes.
+
 """
 
 import asap3

--- a/ptmmodule.c
+++ b/ptmmodule.c
@@ -46,8 +46,8 @@ static PyObject* index_structure(PyObject* self, PyObject* args, PyObject* kw)
 		if (PyArray_DIM(obj_num, 0) != num_nbrs)	//need 14 nearest neighbours + central atom
 			return error(PyExc_TypeError, "numbers array must be contain 15 elements");
 
-		if (PyArray_TYPE(obj_num) != NPY_INT)		//array of ints
-			return error(PyExc_TypeError, "numbers array must be have dtype NPY_INT");
+		if (PyArray_TYPE(obj_num) != NPY_INT32)		//array of ints
+			return error(PyExc_TypeError, "numbers array must be have dtype NPY_INT32");
 
 		if (!PyArray_ISCARRAY_RO(obj_num))		//contiguous etc.
 			return error(PyExc_TypeError, "numbers array must be contiguous array");


### PR DESCRIPTION
Adapt Makefile for inclusion in Asap.
Adapt ptm.py script to use (and test) more info than just the structure.
Remove the link flag -z defs as it is not supported on all architectures.
Change type of atomic numbers from NPY_INT to NPY_INT32 so it could be created correctly in Python.
