### PR TITLE
Fix makefile.  Assume that atomic numbers are 32 bit in Python interface.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = gcc
 
 C_SRC_FILES = canonical.c graph_data.c convex_hull_incremental.c \
 	index_PTM.c alloy_types.c qcprot.c deformation_gradient.c \
-	normalize_vertices.c quat.c unittest.c
+	normalize_vertices.c quat.c
 
 C_SRC_MODULE_FILE = ptmmodule.c 
 
@@ -11,7 +11,11 @@ C_SRC_SVDPOLAR_FILES = polar_decomposition.c
 HEADER_FILES = alloy_types.h canonical.h convex_hull_incremental.h \
 	deformation_gradient.h graph_data.h index_PTM.h \
 	normalize_vertices.h qcprot.h quat.h reference_templates.h \
-	svdpolar/polar_decomposition.h unittest.h
+	svdpolar/polar_decomposition.h \
+	svdpolar/Singular_Value_Decomposition_Givens_QR_Factorization_Kernel.h \
+	svdpolar/Singular_Value_Decomposition_Jacobi_Conjugation_Kernel.h \
+	svdpolar/Singular_Value_Decomposition_Kernel_Declarations.h \
+	svdpolar/Singular_Value_Decomposition_Main_Kernel_Body.h
 
 OBJDIR = .
 
@@ -57,14 +61,11 @@ $(OBJDIR)/$(LIBRARY): $(C_OBJECT_FILES) $(C_OBJECT_SVDPOLAR_FILES)
 $(OBJDIR):
 	mkdir $(OBJDIR)
 
-# Lazy again: all object files depend on all header files
-$(OBJDIR)/%.o: $(HEADER_FILES)
-
 # Rule for compiling C source
-$(OBJDIR)/%.o: svdpolar/%.c
+$(OBJDIR)/%.o: svdpolar/%.c  $(HEADER_FILES)
 	$(CC) -c $(CFLAGS) $(INCLUDES) -o $@ -I$(PYTHONINCLDIR) -I$(NUMPY_INCLUDE) $<
 
-$(OBJDIR)/%.o: %.c
+$(OBJDIR)/%.o: %.c  $(HEADER_FILES)
 	$(CC) -c $(CFLAGS) $(INCLUDES) -o $@ -I$(PYTHONINCLDIR) -I$(NUMPY_INCLUDE) $<
 
 clean:

--- a/ptmmodule.c
+++ b/ptmmodule.c
@@ -179,9 +179,9 @@ PyMODINIT_FUNC initptmmodule(void)
 	import_array();
 
 	initialize_PTM();
-	uint64_t res = run_tests();
-	if (res != 0)
-		return error(PyExc_RuntimeError, "PTM unit tests failed");
+	//uint64_t res = run_tests();
+	//if (res != 0)
+	//	return error(PyExc_RuntimeError, "PTM unit tests failed");
 }
 
 #ifdef __cplusplus

--- a/ptmmodule.c
+++ b/ptmmodule.c
@@ -47,8 +47,8 @@ static PyObject* index_structure(PyObject* self, PyObject* args, PyObject* kw)
 		if (PyArray_DIM(obj_num, 0) != num_nbrs)	//need 14 nearest neighbours + central atom
 			return error(PyExc_TypeError, "numbers array must be contain 15 elements");
 
-		if (PyArray_TYPE(obj_num) != NPY_INT)		//array of ints
-			return error(PyExc_TypeError, "numbers array must be have dtype NPY_INT");
+		if (PyArray_TYPE(obj_num) != NPY_INT32)		//array of ints
+			return error(PyExc_TypeError, "numbers array must be have dtype NPY_INT32 (numpy.int32)");
 
 		if (!PyArray_ISCARRAY_RO(obj_num))		//contiguous etc.
 			return error(PyExc_TypeError, "numbers array must be contiguous array");


### PR DESCRIPTION
Unfortunately, the default integer size in NumPy arrays depends on the architecture and on the version of NumPy.  We therefore have to assume a specific kind of integers in the Python interface, and chose numpy.int32.  The alternative would be to cast the array in the C interface file.

Also fixed a dependency issue in the Makefile, and removed calling the unit tests during module initialization, since module initialization cannot return a Python exception in the normal way (so the code did not compile).
